### PR TITLE
fixed expanding cards transitions for Safari browsers

### DIFF
--- a/expanding-cards/style.css
+++ b/expanding-cards/style.css
@@ -30,7 +30,7 @@ body {
   flex: 0.5;
   margin: 10px;
   position: relative;
-  transition: flex 0.7s ease-in;
+  -webkit-transition: all 700ms ease-in;
 }
 
 .panel h3 {


### PR DESCRIPTION
expanding cards transitions do not work in Safari v.14.0.1 browsers.  This pull request modifies the .panel transition to correct this.  Changes tested in chrome and safari without issues.  Always appreciative of your content Brad!