### PR TITLE
added an  if statement to catch when we click the last cup to toggle it

### DIFF
--- a/drink-water/script.js
+++ b/drink-water/script.js
@@ -10,6 +10,7 @@ smallCups.forEach((cup, idx) => {
 })
 
 function highlightCups(idx) {
+    if (idx===7 && smallCups[idx].classList.contains("full")) idx--;
     if(smallCups[idx].classList.contains('full') && !smallCups[idx].nextElementSibling.classList.contains('full')) {
         idx--
     }


### PR DESCRIPTION
when you click on the last cup to fill it, it works fine, but when you click it again it throws:
`Uncaught TypeError: Cannot read property 'classList' of null
    at highlightCups (script.js:13)`
so I added an if statement at the beginning of the highlightCup function to prevent this from happening.
`if (idx===7 && smallCups[idx].classList.contains("full")) idx--;`