### PR TITLE
Stop drawing when mouse is released outside of the canvas

### DIFF
--- a/drawing-app/script.js
+++ b/drawing-app/script.js
@@ -20,7 +20,7 @@ canvas.addEventListener('mousedown', (e) => {
     y = e.offsetY
 })
 
-canvas.addEventListener('mouseup', (e) => {
+document.addEventListener('mouseup', (e) => {
     isPressed = false
 
     x = undefined


### PR DESCRIPTION
I noticed that when a user draws on the canvas and clicks mouse button on any element outside of it, mousemove event still continues triggering drawing action on the canvas (since mouseup event isn't called on it).

**Steps to reproduce (example):**
Draw something on the canvas and without releasing a mouse, try to change the color. Color input will open and the app will continue drawing simultaneously. 

**Some possible solutions:**

- Set current mouseup event listener on the whole document (as done here in the code). 
- Keep the mouseup event defined on the canvas and write another one on the whole document. This event will set isPressed variable to false anytime the user releases the mouse button outside of the canvas: 

```
document.addEventListener('mouseup', (e) => {
    if (e.target !== canvas) {
        isPressed = false;
    }
}); 
```