### PR TITLE
[Bug Fix] Error on deselecting last cup in project 16

### DIFF
--- a/drink-water/script.js
+++ b/drink-water/script.js
@@ -11,7 +11,7 @@ smallCups.forEach((cup, idx) => {
 
 function highlightCups(idx) {
     if (idx===7 && smallCups[idx].classList.contains("full")) idx--;
-    if(smallCups[idx].classList.contains('full') && !smallCups[idx].nextElementSibling.classList.contains('full')) {
+    else if(smallCups[idx].classList.contains('full') && !smallCups[idx].nextElementSibling.classList.contains('full')) {
         idx--
     }
 


### PR DESCRIPTION
In [16- Drink Water Project](https://50projects50days.com/projects/drink-water/) deselecting the 8th cup i.e. the last cup throws an error as it does not has `nextElementSibling` with `small-cup` class. Adding an `else if` condition fixes this. 