### PR TITLE
Set color picker default value to black

### DIFF
--- a/drawing-app/script.js
+++ b/drawing-app/script.js
@@ -9,7 +9,8 @@ const ctx = canvas.getContext('2d');
 
 let size = 10
 let isPressed = false
-let color = 'black'
+colorEl.value = 'black'
+let color = colorEl.value
 let x
 let y
 


### PR DESCRIPTION
I noticed that color picker HTML element retains the last picked value from user even after the page is reloaded. This will cause inconsistency between `color` value and the actual `colorEl.value`.

This commit will always initialize color picker default value to black, the same way that `color` variable was set originally.