### PR TITLE
Improving style.css for password generator

### DIFF
--- a/password-generator/style.css
+++ b/password-generator/style.css
@@ -47,7 +47,10 @@ h2 {
 .result-container #result {
   word-wrap: break-word;
   max-width: calc(100% - 40px);
+  overflow-y: scroll;
+  height: 100%;
 }
+
 
 .result-container .btn {
   position: absolute;

--- a/password-generator/style.css
+++ b/password-generator/style.css
@@ -51,6 +51,9 @@ h2 {
   height: 100%;
 }
 
+#result::-webkit-scrollbar {
+  width: 1rem;
+}
 
 .result-container .btn {
   position: absolute;


### PR DESCRIPTION
For longer passwords, the text was overflowing 
![image](https://user-images.githubusercontent.com/49295474/122605081-95afdd80-d094-11eb-8ea1-7c2e8de8b664.png)

Added a bit of css so that the text remains inside the #result . Now the use can just scroll to view the entire password or copy the same. The text won't overflow though.
![image](https://user-images.githubusercontent.com/49295474/122605154-af512500-d094-11eb-9d78-053a859692f2.png)
