### PR TITLE
Fix Netflix Logo and Overview in Movie App

### DIFF
--- a/movie-app/style.css
+++ b/movie-app/style.css
@@ -102,7 +102,7 @@ main {
   right: 0;
   max-height: 100%;
   transform: translateY(101%);
-  overflow-y: auto;
+  overflow: scroll;
   transition: transform 0.3s ease-in;
 }
 

--- a/netflix-mobile-navigation/index.html
+++ b/netflix-mobile-navigation/index.html
@@ -12,7 +12,7 @@
       <i class="fas fa-bars"></i>
     </button>
 
-    <img src="https://logos-download.com/wp-content/uploads/2016/03/Netflix_logo.png" alt="Logo" class="logo">
+    <img src="https://upload.wikimedia.org/wikipedia/commons/0/08/Netflix_2015_logo.svg" alt="Logo" class="logo">
 
     <p class="text">Mobile Navigation</p>
 
@@ -23,7 +23,7 @@
             <i class="fas fa-times"></i>
           </button>
 
-          <img src="https://logos-download.com/wp-content/uploads/2016/03/Netflix_logo.png" alt="Logo" class="logo">
+          <img src="https://upload.wikimedia.org/wikipedia/commons/0/08/Netflix_2015_logo.svg" alt="Logo" class="logo">
 
           <ul class="list">
             <li><a href="#">Teams</a></li>


### PR DESCRIPTION
**Netflix Logo** in "Netflix Mobile Navigation"
The image source "logos-download.com" Netflix logo isn't working.
Fixed this by adding Netflix icon from wiki link.

**Overview** in "Movie App" 
When content is more than card size it was hidden.
Fixed this by adding scroll