### PR TITLE
 Removed null display bug when user profile name or bio was not found in a github profile

### DIFF
--- a/github-profiles/script.js
+++ b/github-profiles/script.js
@@ -28,14 +28,16 @@ async function getRepos(username) {
 }
 
 function createUserCard(user) {
+    const userID = user.name || user.login
+    const userBio = user.bio ? `<p>${user.bio}</p>` : ''
     const cardHTML = `
     <div class="card">
     <div>
       <img src="${user.avatar_url}" alt="${user.name}" class="avatar">
     </div>
     <div class="user-info">
-      <h2>${user.name}</h2>
-      <p>${user.bio}</p>
+      <h2>${userID}</h2>
+      ${userBio}
       <ul>
         <li>${user.followers} <strong>Followers</strong></li>
         <li>${user.following} <strong>Following</strong></li>


### PR DESCRIPTION
### Changelog
- Removed `null` display bug if user's profile name was not found from `github` 
- Removed `null` display bug if user's profile bio was not found from `github`

### Description
- Before

- If I search using my github username `rafat17` with no user `name` available
 
![rafat17 bug](https://user-images.githubusercontent.com/43632236/127744037-82b53c03-7c2e-4177-b2ea-a6ddff185be2.png)

- If I search using my friend's github username `tahsinur-aalto` with no user` name` and `description` available
 
![tahsinbug](https://user-images.githubusercontent.com/43632236/127744093-0467d99d-0bc1-4a9a-90a4-d8a30ecf9aba.png)


- After 

- If I search using my github username `rafat17` with no user `name` available
 
![rafa17fix](https://user-images.githubusercontent.com/43632236/127744286-0edf98ee-5446-4714-a8ab-512b69eb5a87.png)

- If I search using my friend's github username `tahsinur-aalto` with no user` name` and `description` available
 
![tahsinfix](https://user-images.githubusercontent.com/43632236/127744295-e55eb97c-15d2-4bc1-8625-98c041702a99.png)



   