### PR TITLE
Fixed: Todo ui getting hidden on adding multiple todos

### DIFF
--- a/todo-list/style.css
+++ b/todo-list/style.css
@@ -12,7 +12,6 @@ body {
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  height: 100vh;
   margin: 0;
 }
 


### PR DESCRIPTION
On adding multipe todos at once, the original todos logo and enter todo box was getting hidden.
Added a fix to show the todo box, irrespective of how many todos are added.
Changed styles.css file of tod
![ss](https://user-images.githubusercontent.com/28520296/135645368-3e01d966-0e72-4efc-81d6-2f27985e4142.PNG)
o