### PR TITLE
Updated button ripple effect

### DIFF
--- a/button-ripple-effect/script.js
+++ b/button-ripple-effect/script.js
@@ -2,8 +2,8 @@ const buttons = document.querySelectorAll('.ripple')
 
 buttons.forEach(button => {
     button.addEventListener('click', function (e) {
-        const x = e.clientX
-        const y = e.clientY
+        const x = e.pageX
+        const y = e.pageY
 
         const buttonTop = e.target.offsetTop
         const buttonLeft = e.target.offsetLeft


### PR DESCRIPTION
I updated the ripple effect to using event.pageX and event.pageY because once the height of the body changes and the page becomes scrollable, the ripple effect is off of its y-axis when the page is scrolled.

event.pageY is relative to the page height and it makes sense to subtract event.target.offsetTop from it. While event.clientY is relative to the screen size which may not provide the expected result. However, for the current use case, it is fine. I felt I should make the pull request because I reused the code in my personal project and spent quite some time fixing this for my use case.