### PR TITLE
fixed image links

### DIFF
--- a/feedback-ui-design/index.html
+++ b/feedback-ui-design/index.html
@@ -12,17 +12,23 @@
       <strong>How satisfied are you with our <br /> customer support performance?</strong>
       <div class="ratings-container">
         <div class="rating">
-          <img src="https://image.flaticon.com/icons/svg/187/187150.svg" alt="">
+          <img
+            src="https://img.icons8.com/external-tulpahn-outline-color-tulpahn/64/000000/external-sad-emotion-tulpahn-outline-color-tulpahn.png"
+          />
           <small>Unhappy</small>
         </div>
 
         <div class="rating">
-          <img src="https://image.flaticon.com/icons/svg/187/187136.svg" alt=""/>
+          <img
+            src="https://img.icons8.com/external-tulpahn-outline-color-tulpahn/64/000000/external-unconcerned-emotion-tulpahn-outline-color-tulpahn.png"
+          />
           <small>Neutral</small>
         </div>
 
         <div class="rating active">
-          <img src="https://image.flaticon.com/icons/svg/187/187133.svg" alt=""/>
+          <img
+            src="https://img.icons8.com/external-tulpahn-outline-color-tulpahn/64/000000/external-emoji-birthday-party-tulpahn-outline-color-tulpahn.png"
+          />
           <small>Satisfied</small>
         </div>
       </div>


### PR DESCRIPTION
In the project 'Feedback UI Design', the image links were not working as shown below -
![Screenshot (20)](https://user-images.githubusercontent.com/67976672/150645821-65af119b-3c06-441c-90cc-1a2a3643e501.png)

I fixed the image links by getting images from Icons8 as I was not able to find same emoticons on falticon. Now it looks like -

![Screenshot (21)](https://user-images.githubusercontent.com/67976672/150645849-c45222af-6bc9-4626-9e5b-5806e0c59cc0.png)
