### PR TITLE
Fix : Netflix Logo link updated

### DIFF
--- a/netflix-mobile-navigation/index.html
+++ b/netflix-mobile-navigation/index.html
@@ -12,7 +12,7 @@
       <i class="fas fa-bars"></i>
     </button>
 
-    <img src="https://logos-download.com/wp-content/uploads/2016/03/Netflix_Logo_2014-700x188.png" alt="Logo" class="logo">
+    <img src="https://upload.wikimedia.org/wikipedia/commons/0/08/Netflix_2015_logo.svg" alt="Logo" class="logo">
 
     <p class="text">Mobile Navigation</p>
 
@@ -23,7 +23,7 @@
             <i class="fas fa-times"></i>
           </button>
 
-          <img src="https://logos-download.com/wp-content/uploads/2016/03/Netflix_Logo_2014-700x188.png" alt="Logo" class="logo">
+          <img src="https://upload.wikimedia.org/wikipedia/commons/0/08/Netflix_2015_logo.svg" alt="Logo" class="logo">
 
           <ul class="list">
             <li><a href="#">Teams</a></li>


### PR DESCRIPTION
Netflix Logo in "Netflix Mobile Navigation"
The image source "logos-download.com" Netflix logo isn't working.
Fixed this by adding Netflix icon from wiki link
![before](https://user-images.githubusercontent.com/63870995/181034724-37477817-4cac-479e-85d2-f89c6925920c.png)
![after](https://user-images.githubusercontent.com/63870995/181034748-8631b96d-9f84-46ed-bf6b-9b13b3a0058f.png)
.