### PR TITLE
Remove deprecated execComand() function

### DIFF
--- a/password-generator/script.js
+++ b/password-generator/script.js
@@ -15,16 +15,11 @@ const randomFunc = {
 }
 
 clipboardEl.addEventListener('click', () => {
-    const textarea = document.createElement('textarea')
-    const password = resultEl.innerText
-
-    if(!password) { return }
-
-    textarea.value = password
-    document.body.appendChild(textarea)
-    textarea.select()
-    document.execCommand('copy')
-    textarea.remove()
+    const password = resultEl.innerText;
+  if (!password) {
+    return;
+  }
+  navigator.clipboard.writeText(password);
     alert('Password copied to clipboard!')
 })
 


### PR DESCRIPTION
Document.execCommand() has been deprecated and altthough some browsers might still support it, it may have already been removed from the relevant web standards, may be in the process of being dropped, or may only be kept for compatibility purposes, my alternative uses instead the Clipboard API to copy the generated password to the clipboard