### PR TITLE
removed height property set for the body tag

### DIFF
--- a/todo-list/style.css
+++ b/todo-list/style.css
@@ -12,7 +12,6 @@ body {
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  height: 100vh;
   margin: 0;
 }
 


### PR DESCRIPTION
After creating multiple todos  ,the header  **<h1> todos <h1>**  is not displayed correctly due to viewport-percentage length set for the body. I thought it was better to remove the height property.