### PR TITLE
fix: wrong click to heart icon when fast click

### DIFF
--- a/double-click-heart/style.css
+++ b/double-click-heart/style.css
@@ -40,6 +40,7 @@ small {
 }
 
 .loveMe .fa-heart {
+  pointer-events: none;
   position: absolute;
   animation: grow 0.6s linear;
   transform: translate(-50%, -50%) scale(0);


### PR DESCRIPTION
When clicking continuously and quickly, the click target will change from the picture to the heart icon, resulting in the wrong positioning of the heart icon behind