### PR TITLE
Fix_URL Unsplash's random server is down. use Picsum as an alternative while waiting Unsplash update

### DIFF
--- a/random-image-generator/script.js
+++ b/random-image-generator/script.js
@@ -1,17 +1,22 @@
-const container = document.querySelector('.container')
-const unsplashURL = 'https://source.unsplash.com/random/'
-const rows = 5
+const container = document.querySelector('.container');
+const unsplashURL = 'https://source.unsplash.com/random/';
+const picsumURL = 'https://picsum.photos';
+const rows = 5;
 
-for(let i = 0; i < rows * 3; i++) {
-    const img = document.createElement('img')
-    img.src = `${unsplashURL}${getRandomSize()}`
-    container.appendChild(img)
+for (let i = 0; i < rows * 3; i++) {
+	const img = document.createElement('img');
+	/* Unplash's server is down at the moment. Use 'picsum' instead
+    img.src = `${unsplashURL}${getRandomSize()}`;
+    */
+	// Picsum URL: https://picsum.photos/<width>/<height>/?<randomChar>
+	img.src = `${picsumURL}/${getRandomNr()}/${getRandomNr()}/?${i}`;
+	container.appendChild(img);
 }
 
 function getRandomSize() {
-    return `${getRandomNr()}x${getRandomNr()}`
+	return `${getRandomNr()}x${getRandomNr()}`;
 }
 
 function getRandomNr() {
-    return Math.floor(Math.random() * 10) + 300
+	return Math.floor(Math.random() * 10) + 300;
 }


### PR DESCRIPTION
### Reason:
-  I've seen **Unsplash**'s random-page display **Herouku**-like error (free Heroku version is disabled 28 Nov 2022). I think we need to wait for its updating, while that I suggest another way to request images for this project by using **picsum**.
- ![image](https://user-images.githubusercontent.com/74447462/204149966-80e5affb-9d5e-4365-992b-5311e0cf9326.png)

### How to:
- Homepage: https://picsum.photos/
  - this is [guide for unique random image](https://dev.to/desi/using-the-unsplash-api-to-display-random-images-15co#comment-c7gm) from a person post
  - With `?<randomChar>` query, it return different images even in same dimension