### PR TITLE
Fix Unsplash's random server down with alternative - picsum

### DIFF
--- a/random-image-generator/script.js
+++ b/random-image-generator/script.js
@@ -1,10 +1,16 @@
 const container = document.querySelector('.container')
 const unsplashURL = 'https://source.unsplash.com/random/'
+const picsumURL = 'https://picsum.photos'
 const rows = 5
 
 for(let i = 0; i < rows * 3; i++) {
     const img = document.createElement('img')
-    img.src = `${unsplashURL}${getRandomSize()}`
+    /* 
+    Unplash's random-server is down at the moment. Use 'picsum' instead
+    Picsum URL: https://picsum.photos/<width>/<height>/?<randomChar>
+    */
+   // img.src = `${unsplashURL}${getRandomSize()}`;
+	img.src = `${picsumURL}/${getRandomNr()}/${getRandomNr()}/?${i}`;
     container.appendChild(img)
 }
 


### PR DESCRIPTION
### Reason:

-  I've seen [**Unsplash**'s random-page](https://source.unsplash.com/random/) display **Herouku**-like error (free Heroku version is disabled 28 Nov 2022). I think we need to wait for its updating, while that I suggest another way to request images for this project by using [**picsum**](https://picsum.photos/).

![image](https://user-images.githubusercontent.com/74447462/204149966-80e5affb-9d5e-4365-992b-5311e0cf9326.png)

### Usage:
`https://picsum.photos/<width>/<height>/?<randomChar>`
- A guide for request non-repeat images, from a [comment](https://dev.to/desi/using-the-unsplash-api-to-display-random-images-15co#comment-c7gm)
- With different `?<randomChar>` , it return different images even in same dimension
> Test link: https://picsum.photos/303/301/?1

![image](https://user-images.githubusercontent.com/74447462/204150781-f362dd36-ac72-4c56-b3ac-00d6f27cb146.png)
