### PR TITLE
fix: correct css file name

### DIFF
--- a/event-keycodes/index.html
+++ b/event-keycodes/index.html
@@ -3,14 +3,12 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link rel="stylesheet" href="style.css" />
+    <link rel="stylesheet" href="dark-style.css" />
     <title>Event KeyCodes</title>
   </head>
   <body>
     <div id="insert">
-      <div class="key">
-        Press any key to get the keyCode
-      </div>
+      <div class="key">Press any key to get the keyCode</div>
     </div>
     <script src="script.js"></script>
   </body>


### PR DESCRIPTION
forget to change css file name after updating dark mode css

`<link rel="stylesheet" href="style.css" />` 
=> 
`<link rel="stylesheet" href="dark-style.css" />` 