### PR TITLE
Prevent error caused by index out of bounds

### DIFF
--- a/verify-account-ui/script.js
+++ b/verify-account-ui/script.js
@@ -6,9 +6,9 @@ codes.forEach((code, idx) => {
     code.addEventListener('keydown', (e) => {
         if(e.key >= 0 && e.key <=9) {
             codes[idx].value = ''
-            setTimeout(() => codes[idx + 1].focus(), 10)
+            setTimeout(() => codes[idx < codes.length - 1 ? idx + 1 : idx].focus(), 10)
         } else if(e.key === 'Backspace') {
-            setTimeout(() => codes[idx - 1].focus(), 10)
+            setTimeout(() => codes[idx > 0 ? idx - 1 : idx].focus(), 10)
         }
     })
 })


### PR DESCRIPTION
Fix the error `Cannot read properties of undefined (reading 'focus')` caused by index out of bounds