### PR TITLE
Fixed margin issue in .code element

### DIFF
--- a/verify-account-ui/style.css
+++ b/verify-account-ui/style.css
@@ -38,7 +38,7 @@ body {
   height: 120px;
   width: 100px;
   border: 1px solid #eee;
-  margin: 1%;
+  margin: 7px;
   text-align: center;
   font-weight: 300;
   -moz-appearance: textfield;


### PR DESCRIPTION
The .code element was overflowing the container, causing display issues. This commit fixes the issue by adjusting the margin to prevent overflow.  

-> Before

![image](https://user-images.githubusercontent.com/77185999/230376313-2601d988-5d13-469b-bde6-94191f2c46cc.png)

-> After

![image](https://user-images.githubusercontent.com/77185999/230376514-14dbdad8-b328-4aec-b3c1-9d2514101a21.png)
