### PR TITLE
Modify css styles to prevent toggle button overlap

### DIFF
--- a/theme-clock/style.css
+++ b/theme-clock/style.css
@@ -26,6 +26,7 @@ html.dark {
 body {
   font-family: 'Heebo', sans-serif;
   display: flex;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
   height: 100vh;
@@ -40,8 +41,9 @@ body {
   border: 0;
   border-radius: 4px;
   padding: 8px 12px;
-  position: absolute;
-  top: 100px;
+  position: relative;
+  top: 0;
+  margin-bottom: 80px;
 }
 
 .toggle:focus {


### PR DESCRIPTION
1. Add 'flex-direction: column' to body so the toggle button is displayed above the clock. (on smaller screens the button is pushed to the left side).

2. On smaller screens the toggle button overlaps the clock:
![theme-clock-original](https://github.com/bradtraversy/50projects50days/assets/66838571/59d5952c-64cf-4baa-b591-6410fb3af8f0)

- Change position of toggle button from absolute to relative.
- Change top to 0px
- Add margin to the bottom

Result:
On smaller screens, the toggle button does not overlap the clock
![theme-clock-final](https://github.com/bradtraversy/50projects50days/assets/66838571/3da8325a-306c-4094-b732-97d3a9b05c3f)

And is still visible:
![theme-clock-main](https://github.com/bradtraversy/50projects50days/assets/66838571/3fa922e4-b20f-4d89-9600-a41ed82baacb)